### PR TITLE
feat: 把主要的網頁app container從Fargate移至EC2上執行

### DIFF
--- a/deployment/infra/.terraform.lock.hcl
+++ b/deployment/infra/.terraform.lock.hcl
@@ -6,6 +6,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   constraints = "~> 5.0"
   hashes = [
     "h1:a/VEUu6BGQSPlUAzbN+zqaDCdi0QGh/VzBgo2gCran0=",
+    "h1:hqoQJnKaTfzNge5oCELAs+jqiT0R0oygDYlG4pmy3yk=",
     "zh:3f7e734abb9d647c851f5cb987837d7c073c9cbf1f520a031027d827f93d3b68",
     "zh:5ca9400360a803a11cf432ca203be9f09da8fff9c96110a83c9029102b18c9d5",
     "zh:5d421f475d467af182a527b7a61d50105dc63394316edf1c775ef736f84b941c",
@@ -21,5 +22,24 @@ provider "registry.terraform.io/hashicorp/aws" {
     "zh:dbbf98b3cd8003833c472bdb89321c17a9bbdc1b785e7e3d75f8af924ee5a0e4",
     "zh:df86cf9311a4be8bb4a251196650653f97e01fbf5fe72deecc8f28a35a5352ae",
     "zh:f92992881afd9339f3e539fcd90cfc1e9ed1356b5e760bbcc804314c3cd6837f",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/tls" {
+  version = "4.1.0"
+  hashes = [
+    "h1:Ka8mEwRFXBabR33iN/WTIEW6RP0z13vFsDlwn11Pf2I=",
+    "zh:14c35d89307988c835a7f8e26f1b83ce771e5f9b41e407f86a644c0152089ac2",
+    "zh:2fb9fe7a8b5afdbd3e903acb6776ef1be3f2e587fb236a8c60f11a9fa165faa8",
+    "zh:35808142ef850c0c60dd93dc06b95c747720ed2c40c89031781165f0c2baa2fc",
+    "zh:35b5dc95bc75f0b3b9c5ce54d4d7600c1ebc96fbb8dfca174536e8bf103c8cdc",
+    "zh:38aa27c6a6c98f1712aa5cc30011884dc4b128b4073a4a27883374bfa3ec9fac",
+    "zh:51fb247e3a2e88f0047cb97bb9df7c228254a3b3021c5534e4563b4007e6f882",
+    "zh:62b981ce491e38d892ba6364d1d0cdaadcee37cc218590e07b310b1dfa34be2d",
+    "zh:bc8e47efc611924a79f947ce072a9ad698f311d4a60d0b4dfff6758c912b7298",
+    "zh:c149508bd131765d1bc085c75a870abb314ff5a6d7f5ac1035a8892d686b6297",
+    "zh:d38d40783503d278b63858978d40e07ac48123a2925e1a6b47e62179c046f87a",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:fb07f708e3316615f6d218cec198504984c0ce7000b9f1eebff7516e384f4b54",
   ]
 }

--- a/deployment/infra/app_cluster.tf
+++ b/deployment/infra/app_cluster.tf
@@ -2,20 +2,34 @@
 resource "aws_ecs_cluster" "lab_app_cluster" {
   name = "lab-app-cluster"
 }
+resource "aws_ecs_capacity_provider" "lab_app_ec2_capacity_provider" {
+  name = "lab-app-capacity-provider"
+
+  auto_scaling_group_provider {
+    auto_scaling_group_arn = aws_autoscaling_group.lab_ec2_autoscaling_group.arn
+    managed_draining       = "ENABLED"
+
+
+    managed_scaling {
+      maximum_scaling_step_size = 1
+      minimum_scaling_step_size = 1
+      status                    = "ENABLED"
+      target_capacity           = 100
+    }
+  }
+}
+
 resource "aws_ecs_cluster_capacity_providers" "lab_app_cluster_capacity_providers" {
   cluster_name = aws_ecs_cluster.lab_app_cluster.name
 
-  capacity_providers = ["FARGATE", "FARGATE_SPOT"]
+  capacity_providers = [
+    aws_ecs_capacity_provider.lab_app_ec2_capacity_provider.name,
+    "FARGATE", "FARGATE_SPOT"
+  ]
 
   default_capacity_provider_strategy {
-    base              = 0
+    capacity_provider = aws_ecs_capacity_provider.lab_app_ec2_capacity_provider.name
     weight            = 1
-    capacity_provider = "FARGATE"
-  }
-  default_capacity_provider_strategy {
-    base              = 0
-    weight            = 1
-    capacity_provider = "FARGATE_SPOT"
   }
 }
 
@@ -25,84 +39,3 @@ resource "aws_cloudwatch_log_group" "app_logs" {
   retention_in_days = 14 # retain logs for 2 weeks (adjust as needed)
 }
 
-# ECS Task Definition for Laravel app
-resource "aws_ecs_task_definition" "laravel_app" {
-  family                   = "lab-laravel-task" # task family name
-  cpu                      = "256"              # 1/4 vCPU
-  memory                   = "512"              # 0.5 GB
-  network_mode             = "awsvpc"
-  requires_compatibilities = ["FARGATE"]
-  execution_role_arn       = data.aws_iam_role.lab_role.arn
-  task_role_arn            = data.aws_iam_role.lab_role.arn
-  container_definitions = jsonencode([
-    {
-      name      = "final-app"
-      image     = "ghcr.io/nthu-cp-01/final:main"
-      essential = true
-      healthCheck = {
-        command     = ["CMD-SHELL", "curl -f http://localhost/up || exit 1"]
-        interval    = 300
-        timeout     = 5
-        retries     = 3
-        startPeriod = 120
-      }
-      portMappings = [
-        {
-          containerPort = 80
-          hostPort      = 80
-        }
-      ]
-      environment = [
-        # Application
-        { name = "APP_NAME", value = "AWS" },
-        { name = "APP_ENV", value = "production" },
-        { name = "APP_KEY", value = "base64:3vVjC2JIukr6/8WQrd3cxYsdn4DKNn35h3/t/uIaG5M=" },
-        { name = "APP_URL", value = "http://localhost" },
-        { name = "APP_DEBUG", value = "true" },
-        { name = "APP_LOCALE", value = "en" },
-        { name = "APP_FALLBACK_LOCALE", value = "en" },
-        { name = "APP_TIMEZONE", value = "UTC+8" },
-
-        # Database
-        { name = "DB_CONNECTION", value = "pgsql" },
-        { name = "DB_HOST", value = aws_db_instance.lab_rds_instance.address },
-        { name = "DB_PORT", value = tostring(aws_db_instance.lab_rds_instance.port) },
-        { name = "DB_DATABASE", value = aws_db_instance.lab_rds_instance.db_name },
-        { name = "DB_USERNAME", value = aws_db_instance.lab_rds_instance.username },
-        { name = "DB_PASSWORD", value = "cppassword" },
-
-        # Cache
-        { name = "REDIS_CLIENT", value = "predis" },
-        { name = "REDIS_HOST", value = aws_elasticache_replication_group.lab_redis.primary_endpoint_address },
-        { name = "REDIS_PORT", value = "6379" },
-        { name = "REDIS_USERNAME", value = "default" },
-        { name = "REDIS_PASSWORD", value = "default" },
-        { name = "CACHE_DRIVER", value = "redis" },
-        { name = "QUEUE_CONNECTION", value = "redis" },
-
-        # Session
-        { name = "SESSION_DRIVER", value = "redis" },
-        { name = "SESSION_CONNECTION", value = "default" },
-        { name = "SESSION_LIFETIME", value = "120" },
-        { name = "SESSION_ENCRYPT", value = "false" },
-        { name = "SESSION_PATH", value = "/" },
-        { name = "SESSION_DOMAIN", value = "null" },
-
-        # Storage(swap with S3 maybe?)
-        { name = "FILESYSTEM_DISK", value = "local" },
-      ]
-      logConfiguration = {
-        logDriver = "awslogs",
-        options = {
-          "awslogs-region"        = "us-east-1",
-          "awslogs-group"         = aws_cloudwatch_log_group.app_logs.name,
-          "awslogs-stream-prefix" = "laravel"
-        }
-      }
-    }
-  ])
-  runtime_platform {
-    operating_system_family = "LINUX"
-    cpu_architecture        = "X86_64"
-  }
-}

--- a/deployment/infra/app_ec2.tf
+++ b/deployment/infra/app_ec2.tf
@@ -1,0 +1,58 @@
+# How to get image id:
+# https://docs.aws.amazon.com/AmazonECS/latest/developerguide/retrieve-ecs-optimized_AMI.html
+locals {
+  ec2_launch_script = <<EOF
+#!/bin/bash
+echo ECS_CLUSTER=${aws_ecs_cluster.lab_app_cluster.name} >> /etc/ecs/ecs.config
+EOF
+}
+
+resource "aws_launch_template" "lab_ec2_template" {
+  name_prefix   = "Lab_EC2_Launch_Template"
+  image_id      = "ami-04c73aa7cd73f7830"
+  instance_type = "t3.micro"
+
+  key_name               = "vockey"
+  vpc_security_group_ids = [aws_security_group.ecs_sg.id]
+  iam_instance_profile {
+    name = "LabInstanceProfile"
+  }
+
+  block_device_mappings {
+    device_name = "/dev/xvda"
+    ebs {
+      volume_size = 30
+      volume_type = "gp2"
+    }
+  }
+
+  tag_specifications {
+    resource_type = "instance"
+    tags = {
+      Name = "ecs-instance"
+    }
+  }
+
+  user_data = base64encode(local.ec2_launch_script)
+}
+
+resource "aws_autoscaling_group" "lab_ec2_autoscaling_group" {
+  vpc_zone_identifier = [
+    aws_subnet.lab_private_subnet_a.id,
+    aws_subnet.lab_private_subnet_b.id
+  ]
+  desired_capacity = 1
+  max_size         = 1
+  min_size         = 1
+
+  launch_template {
+    id      = aws_launch_template.lab_ec2_template.id
+    version = "$Latest"
+  }
+
+  tag {
+    key                 = "AmazonECSManaged"
+    value               = true
+    propagate_at_launch = true
+  }
+}

--- a/deployment/infra/app_migration_task.tf
+++ b/deployment/infra/app_migration_task.tf
@@ -86,10 +86,9 @@ resource "aws_scheduler_schedule" "migration_once" {
     role_arn = data.aws_iam_role.lab_role.arn
 
     ecs_parameters { # ECS RunTask parameters&#8203;:contentReference[oaicite:5]{index=5}
-      task_definition_arn = aws_ecs_task_definition.laravel_run_migration.arn
-      launch_type         = "FARGATE"
-      platform_version    = "1.4.0" # Use latest Fargate platform
-      task_count          = 1
+      task_definition_arn    = aws_ecs_task_definition.laravel_run_migration.arn
+      task_count             = 1
+      enable_execute_command = true
 
       network_configuration {    # Networking for awsvpc mode&#8203;:contentReference[oaicite:6]{index=6}
         assign_public_ip = false # Task in private subnets
@@ -98,6 +97,16 @@ resource "aws_scheduler_schedule" "migration_once" {
           aws_subnet.lab_private_subnet_b.id
         ]
         security_groups = [aws_security_group.ecs_sg.id]
+      }
+
+      capacity_provider_strategy {
+        capacity_provider = "FARGATE_SPOT"
+        weight            = 4
+      }
+
+      capacity_provider_strategy {
+        capacity_provider = "FARGATE"
+        weight            = 1
       }
     }
   }

--- a/deployment/infra/app_service.tf
+++ b/deployment/infra/app_service.tf
@@ -1,12 +1,98 @@
+# ECS Task Definition for Laravel app
+resource "aws_ecs_task_definition" "laravel_app" {
+  family                   = "lab-laravel-task" # task family name
+  cpu                      = "1024"             # 1/4 vCPU
+  memory                   = "512"              # 0.5 GB
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["EC2"]
+  execution_role_arn       = data.aws_iam_role.lab_role.arn
+  task_role_arn            = data.aws_iam_role.lab_role.arn
+  track_latest             = true
+  container_definitions = jsonencode([
+    {
+      name      = "final-app"
+      image     = "ghcr.io/nthu-cp-01/final:main"
+      essential = true
+      healthCheck = {
+        command     = ["CMD-SHELL", "curl -f http://localhost/up || exit 1"]
+        interval    = 300
+        timeout     = 5
+        retries     = 3
+        startPeriod = 120
+      }
+      portMappings = [
+        {
+          containerPort = 80
+          hostPort      = 80
+        }
+      ]
+      environment = [
+        # Application
+        { name = "APP_NAME", value = "AWS" },
+        { name = "APP_ENV", value = "production" },
+        { name = "APP_KEY", value = "base64:3vVjC2JIukr6/8WQrd3cxYsdn4DKNn35h3/t/uIaG5M=" },
+        { name = "APP_URL", value = "http://localhost" },
+        { name = "APP_DEBUG", value = "true" },
+        { name = "APP_LOCALE", value = "en" },
+        { name = "APP_FALLBACK_LOCALE", value = "en" },
+        { name = "APP_TIMEZONE", value = "UTC+8" },
+
+        # Database
+        { name = "DB_CONNECTION", value = "pgsql" },
+        { name = "DB_HOST", value = aws_db_instance.lab_rds_instance.address },
+        { name = "DB_PORT", value = tostring(aws_db_instance.lab_rds_instance.port) },
+        { name = "DB_DATABASE", value = aws_db_instance.lab_rds_instance.db_name },
+        { name = "DB_USERNAME", value = aws_db_instance.lab_rds_instance.username },
+        { name = "DB_PASSWORD", value = "cppassword" },
+
+        # Cache
+        { name = "REDIS_CLIENT", value = "predis" },
+        { name = "REDIS_HOST", value = aws_elasticache_replication_group.lab_redis.primary_endpoint_address },
+        { name = "REDIS_PORT", value = "6379" },
+        { name = "REDIS_USERNAME", value = "default" },
+        { name = "REDIS_PASSWORD", value = "default" },
+        { name = "CACHE_DRIVER", value = "redis" },
+        { name = "QUEUE_CONNECTION", value = "redis" },
+
+        # Session
+        { name = "SESSION_DRIVER", value = "redis" },
+        { name = "SESSION_CONNECTION", value = "default" },
+        { name = "SESSION_LIFETIME", value = "120" },
+        { name = "SESSION_ENCRYPT", value = "false" },
+        { name = "SESSION_PATH", value = "/" },
+        { name = "SESSION_DOMAIN", value = "null" },
+
+        # Storage(swap with S3 maybe?)
+        { name = "FILESYSTEM_DISK", value = "local" },
+      ]
+      logConfiguration = {
+        logDriver = "awslogs",
+        options = {
+          "awslogs-region"        = "us-east-1",
+          "awslogs-group"         = aws_cloudwatch_log_group.app_logs.name,
+          "awslogs-stream-prefix" = "laravel"
+        }
+      }
+    }
+  ])
+  runtime_platform {
+    operating_system_family = "LINUX"
+    cpu_architecture        = "X86_64"
+  }
+}
+
 # ECS Service to run the Laravel task
 resource "aws_ecs_service" "web_service" {
   name                   = "lab-final-laravel-service"
   cluster                = aws_ecs_cluster.lab_app_cluster.id
   task_definition        = aws_ecs_task_definition.laravel_app.arn
   enable_execute_command = true
-  launch_type            = "FARGATE"
-  platform_version       = "1.4.0" # latest Fargate platform (supports secrets fetch, etc.)
   desired_count          = 1
+
+  capacity_provider_strategy {
+    capacity_provider = aws_ecs_capacity_provider.lab_app_ec2_capacity_provider.name
+    weight            = 1
+  }
 
   network_configuration {
     subnets = [


### PR DESCRIPTION
因為他scaling沒有設定0的選項，再加上Fargate並沒有free-tier，導致這樣反而沒有比用Free-tier免費750hr的EC2來得省錢。

所以目前的作法是把Fargate執行網頁的容器改用EC2跑(都是用ECS)，但是原本執行database migration的容器就還是用Fargate執行，但保留Fargate spot的選項，想說能省一點是一點。

(我目前credit用到6.8/50了，所以這個變更還是很有必要的)